### PR TITLE
Refactor UpdateButton

### DIFF
--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -113,6 +113,7 @@ end
 function mod:UpdateButton(event, button)
 	local settings = self.db.profile
 	local text = texts[button]
+	local link = button:GetItemLink()
 	--Integration with SyLevel. If useSyLevel then let SyLevel handle item level logic.
 	if SyLevel then	
 		if settings.useSyLevel then
@@ -128,7 +129,6 @@ function mod:UpdateButton(event, button)
 	local level --The level to display for this item
 	local color --should be a table of color values to be passed to SetTextColor like returned by GetItemQualityColor()
 	local shouldShow = false --Set to true if this text should be shown
-	local link = button:GetItemLink()
 	--Item Logic
 	if link then
 		local objectTable = { strsplit(":", string.match(link, "|H(.-)|h")) } --see https://wow.gamepedia.com/ItemString for more info

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -122,6 +122,7 @@ function mod:UpdateButton(event, button)
 			if text then
 				text:Hide()
 			end
+			SyLevel:CallFilters('Adibags', button, link)
 			return
 		else
 			SyLevel:CallFilters('Adibags', button, nil)

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -36,6 +36,7 @@ local min = _G.min
 local pairs = _G.pairs
 local select = _G.select
 local unpack = _G.unpack
+local wipe = _G.wipe
 --GLOBALS>
 
 local mod = addon:NewModule('ItemLevel', 'ABEvent-1.0')
@@ -176,6 +177,13 @@ function mod:UpdateButton(event, button)
 	updateCache[button] = link
 end
 
+local function SetOptionAndUpdate(info, value)
+	mod.db.profile[info[#info]] = value
+	wipe(updateCache)
+	for button, text in pairs(texts) do
+		mod:UpdateButton(nil, button)
+	end
+end
 
 function mod:GetOptions()
 	return {
@@ -184,12 +192,14 @@ function mod:GetOptions()
 			desc = L['Let SyLevel handle the the display.'],
 			type = 'toggle',
 			order = 5,
+			set = SetOptionAndUpdate,
 		} or nil,
 		equippableOnly = {
 			name = L['Only equippable items'],
 			desc = L['Do not show level of items that cannot be equipped.'],
 			type = 'toggle',
 			order = 10,
+			set = SetOptionAndUpdate,
 		},
 		colorScheme = {
 			name = L['Color scheme'],
@@ -202,6 +212,7 @@ function mod:GetOptions()
 				level    = L['Related to player level'],
 			},
 			order = 20,
+			set = SetOptionAndUpdate,
 		},
 		minLevel = {
 			name = L['Mininum level'],
@@ -212,24 +223,28 @@ function mod:GetOptions()
 			step = 1,
 			bigStep = 10,
 			order = 30,
+			set = SetOptionAndUpdate,
 		},
 		ignoreJunk = {
 			name = L['Ignore low quality items'],
 			desc = L['Do not show level of poor quality items.'],
 			type = 'toggle',
 			order = 40,
+			set = SetOptionAndUpdate,
 		},
 		ignoreHeirloom = {
 			name = L['Ignore heirloom items'],
 			desc = L['Do not show level of heirloom items.'],
 			type = 'toggle',
 			order = 50,
+			set = SetOptionAndUpdate,
 		},
 		showBattlePetLevels = {
 			name = L['Show battle pet levels'],
 			desc = L['Shows the levels of caged battle pets.'],
 			type = 'toggle',
 			order = 60,
+			set = SetOptionAndUpdate,
 		},
 	}, addon:GetOptionHandler(self)
 end

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -47,6 +47,7 @@ local colorSchemes = {
 }
 
 local texts = {}
+local updateCache = {}
 
 local SyLevel = _G.SyLevel
 local SyLevelBypass
@@ -126,6 +127,7 @@ function mod:UpdateButton(event, button)
 			SyLevel:CallFilters('Adibags', button, nil)
 		end
 	end
+	if updateCache[button] == link then return end
 	local level --The level to display for this item
 	local color --should be a table of color values to be passed to SetTextColor like returned by GetItemQualityColor()
 	local shouldShow = false --Set to true if this text should be shown
@@ -171,6 +173,7 @@ function mod:UpdateButton(event, button)
 	else
 		if text then text:Hide() end
 	end
+	updateCache[button] = link
 end
 
 


### PR DESCRIPTION
Refactors UpdateButton to split Item logic from the Display logic. This was necessary due to multiple changes over the years that have added up and the initial assumption that only items are in your bags.  Things that arent items inlcude Battlepet Cages added in Mists of Pandaria and Mythic Keystones added in Legion.