### PR TITLE
Petlevels

### DIFF
--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -91,6 +91,7 @@ function mod:OnInitialize()
 end
 
 function mod:OnEnable()
+	wipe(updateCache)
 	self:RegisterMessage('AdiBags_UpdateButton', 'UpdateButton')
 	if SyLevel and self.db.profile.useSyLevel and not SyLevel:IsPipeEnabled('Adibags') then
 		SyLevel:EnablePipe('Adibags')

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -182,7 +182,10 @@ end
 local function SetOptionAndUpdate(info, value)
 	mod.db.profile[info[#info]] = value
 	wipe(updateCache)
-	for button, text in pairs(texts) do
+	for button, _ in addon:GetPool("ItemButton"):IterateActiveObjects() do
+		mod:UpdateButton(nil, button)
+	end
+	for button, _ in addon:GetPool("BankItemButton"):IterateActiveObjects() do
 		mod:UpdateButton(nil, button)
 	end
 end


### PR DESCRIPTION
Fixes for two bugs with the refactor of UpdateButton.  

Fix 1 Changes SetOptionAndUpdate to update each displayed button not just buttons that there is an existing text for.  This fixes item levels not showing when changing settings that would cause more text to be displayed.

Fix 2 Wipe cache OnEnable.  Going through a load screen doesn't do a full reloadUI, but adibags handles the changes by calling Disable and then Enable.  OnDisable all the text is hidden, so OnEnable the cache needs to be wiped so that the text can be shown as needed.  This fixes item levels not being show after a loading screen.